### PR TITLE
feat!: Integrate diffusivity measure derivation

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,6 @@ This script was initially created by Pavan Anand, M.D. as a member of the Univer
 
 ## CHANGELOG
 
-### version 0.6.0
+### version 0.7.0
 
-* feat!: allow user to specify number of cores to use for parallelization
-* feat: allow user to request script version independently (via `-v` flag)
-* feat: improved script usage by adding guardrails around discouraged script usage (e.g., passing more than 1 exclusive argument to the script)
-* refactor: cleaned up code base
+* feat!: integrated diffusivity measure derivation (i.e., mean diffusivity ("MD"), axial diffusivity ("AD"), & radial diffusivity ("RD"))

--- a/run_pipeline.sh
+++ b/run_pipeline.sh
@@ -215,50 +215,13 @@ find ${ANALYSIS}/individual -mindepth 1 -maxdepth 1 -type d \
 find ${ANALYSIS}/individual -mindepth 1 -maxdepth 1 -type d \
   | parallel -j ${n_procs} "${SCRIPT_ROOT}/utils/analyze_roi.sh" {} ${ANALYSIS}
 
-  echo "DEBUG: starting diffusion analyses."
+echo -e "\nDEBUG: starting diffusion analyses.\n"
 # MD/AD/RD analyses
-for individual in $(find ${ANALYSIS}/individual -mindepth 1 -maxdepth 1 -type d); do
-  mkdir -p ${individual}/{MD,AD,RD}/{origdata,stats,intermediary}
-  readonly MD_ROOT=${individual}/MD
-  readonly AD_ROOT=${individual}/AD
-  readonly RD_ROOT=${individual}/RD
-  for file in $(find ${DERIVATIVES}/$(basename ${individual}) -mindepth 1 -type f -name "*_MD.nii.gz"); do
-    cp ${file} ${MD_ROOT}/origdata/"$(basename ${file})"
-  done
-  for file in $(find ${DERIVATIVES}/$(basename ${individual}) -mindepth 1 -type f -name "*_L1.nii.gz"); do
-    cp ${file} ${AD_ROOT}/origdata/"$(basename ${file} | sed 's/_L1/_AD/g')"
-  done
-  for study in $(find ${DERIVATIVES}/$(basename ${individual}) -mindepth 1 -type d -regex ".*/derivatives/.*/sub-.*"); do
-    fslmaths ${study}/*_L2.nii.gz -add ${study}/*_L3.nii.gz -div 2 ${RD_ROOT}/origdata/$(basename ${study})_RD.nii.gz
-  done
-  for diff_root in MD_ROOT AD_ROOT RD_ROOT; do
-    for file in $(find ${diff_root}/origdata -type f -name "*_$(basename ${diff_root}).nii.gz"); do
-      fslmaths ${file} \
-        -mas "${individual}/FA/$(basename ${individual})_FA_mask.nii.gz" \
-        "${diff_root}/intermediary/$(basename ${file})"
-    done
-    for file in $(find ${individual}/intermediary -type f -name "*_$(basename ${diff_root}).nii.gz"); do
-      applywarp \
-        -i ${file} \
-        -o ${diff_root}/intermediary/$(basename ${file})_to_target.nii.gz \
-        -r ${FSLDIR}/data/standard/FMRIB58_FA_1mm \
-        -w ${individual}/FA/$(basename ${individual})_FA_to_target_warp.nii.gz
-    done
-    for file in $(find ${individual}/intermediary -type f -name "*_to_target.nii.gz"); do
-      fslmaths ${file} \
-        -mas "${ENIGMA_ROOT}/ENIGMA_DTI_FA_mask.nii.gz" \
-        "${diff_root}/intermediary/$(basename ${individual})_masked_$(basename ${diff_root}).nii.gz"
-    done
-    for file in $(find ${diff_root}/intermediary -type f -name "*_masked_*.nii.gz"); do
-      tbss_skeleton \
-        -i ${ENIGMA_ROOT}/ENIGMA_DTI_FA.nii.gz \
-        -p 0.049 \
-        ${ENIGMA_ROOT}/ENIGMA_DTI_FA_skeleton_mask_dst.nii.gz \
-        ${FSLDIR}/data/standard/LowerCingulum_1mm.nii.gz \
-        ${individual}/FA/$(basename ${individual})_masked_FA.nii.gz \
-        ${diff_root}/stats/$(basename ${individual})_masked_$(basename ${diff_root})_skel.nii.gz \
-        -a ${diff_root}/intermediary/$(basename ${individual})_masked_$(basename ${diff_root}).nii.gz \
-        -s ${ENIGMA_ROOT}/ENIGMA_DTI_FA_mask.nii.gz
-    done
-  done
-done
+
+# Export globals required by `diffusivity.sh`
+export ANALYSIS
+export DERIVATIVES
+
+find ${ANALYSIS}/individual -mindepth 1 -maxdepth 1 -type d \
+  | xargs -I {} basename {} \
+  | parallel -j "${n_procs}" "${SCRIPT_ROOT}"/utils/diffusivity.sh {}

--- a/run_pipeline.sh
+++ b/run_pipeline.sh
@@ -214,3 +214,51 @@ find ${ANALYSIS}/individual -mindepth 1 -maxdepth 1 -type d \
 
 find ${ANALYSIS}/individual -mindepth 1 -maxdepth 1 -type d \
   | parallel -j ${n_procs} "${SCRIPT_ROOT}/utils/analyze_roi.sh" {} ${ANALYSIS}
+
+echo "DEBUG: starting diffusion analyses."
+# MD/AD/RD analyses
+for individual in $(find ${ANALYSIS}/individual -mindepth 1 -maxdepth 1 -type d); do
+  mkdir -p ${individual}/{MD,AD,RD}/{origdata,stats,intermediary}
+  readonly MD_ROOT=${individual}/MD
+  readonly AD_ROOT=${individual}/AD
+  readonly RD_ROOT=${individual}/RD
+  for file in $(find ${DERIVATIVES}/$(basename ${individual}) -mindepth 1 -type f -name "*_MD.nii.gz"); do
+    cp ${file} ${MD_ROOT}/origdata/"$(basename ${file})"
+  done
+  for file in $(find ${DERIVATIVES}/$(basename ${individual}) -mindepth 1 -type f -name "*_L1.nii.gz"); do
+    cp ${file} ${AD_ROOT}/origdata/"$(basename ${file} | sed 's/_L1/_AD/g')"
+  done
+  for study in $(find ${DERIVATIVES}/$(basename ${individual}) -mindepth 1 -type d -regex ".*/derivatives/.*/sub-.*"); do
+    fslmaths ${study}/*_L2.nii.gz -add ${study}/*_L3.nii.gz -div 2 ${RD_ROOT}/origdata/$(basename ${study})_RD.nii.gz
+  done
+  for diff_root in MD_ROOT AD_ROOT RD_ROOT; do
+    for file in $(find ${diff_root}/origdata -type f -name "*_$(basename ${diff_root}).nii.gz"); do
+      fslmaths ${file} \
+        -mas "${individual}/FA/$(basename ${individual})_FA_mask.nii.gz" \
+        "${diff_root}/intermediary/$(basename ${file})"
+    done
+    for file in $(find ${individual}/intermediary -type f -name "*_$(basename ${diff_root}).nii.gz"); do
+      applywarp \
+        -i ${file} \
+        -o ${diff_root}/intermediary/$(basename ${file})_to_target.nii.gz \
+        -r ${FSLDIR}/data/standard/FMRIB58_FA_1mm \
+        -w ${individual}/FA/$(basename ${individual})_FA_to_target_warp.nii.gz
+    done
+    for file in $(find ${individual}/intermediary -type f -name "*_to_target.nii.gz"); do
+      fslmaths ${file} \
+        -mas "${ENIGMA_ROOT}/ENIGMA_DTI_FA_mask.nii.gz" \
+        "${diff_root}/intermediary/$(basename ${individual})_masked_$(basename ${diff_root}).nii.gz"
+    done
+    for file in $(find ${diff_root}/intermediary -type f -name "*_masked_*.nii.gz"); do
+      tbss_skeleton \
+        -i ${ENIGMA_ROOT}/ENIGMA_DTI_FA.nii.gz \
+        -p 0.049 \
+        ${ENIGMA_ROOT}/ENIGMA_DTI_FA_skeleton_mask_dst.nii.gz \
+        ${FSLDIR}/data/standard/LowerCingulum_1mm.nii.gz \
+        ${individual}/FA/$(basename ${individual})_masked_FA.nii.gz \
+        ${diff_root}/stats/$(basename ${individual})_masked_$(basename ${diff_root})_skel.nii.gz \
+        -a ${diff_root}/intermediary/$(basename ${individual})_masked_$(basename ${diff_root}).nii.gz \
+        -s ${ENIGMA_ROOT}/ENIGMA_DTI_FA_mask.nii.gz
+    done
+  done
+done

--- a/utils/diffusivity.sh
+++ b/utils/diffusivity.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+# diffusivity.sh
+# -------------
+# Derive mean, radial, & axial diffusivity measures.
+
+# Assumes that $FSLDIR & $ENIGMA_ROOT are defined in the calling script
+
+set -uo pipefail
+
+readonly SUBJECT="${1}"
+readonly INDIVIDUAL="${ANALYSIS}/individual"
+
+derive_diffusivity_measures() {
+  mkdir -p "${INDIVIDUAL}"/"${SUBJECT}"/{MD,AD,RD}/{origdata,stats,intermediary}
+  cp "${DERIVATIVES}"/"${SUBJECT}"/"${SUBJECT}"_MD.nii.gz "${INDIVIDUAL}"/"${SUBJECT}"/MD/origdata/"${SUBJECT}"_MD.nii.gz
+  cp "${DERIVATIVES}"/"${SUBJECT}"/"${SUBJECT}"_L1.nii.gz "${INDIVIDUAL}"/"${SUBJECT}"/AD/origdata/"${SUBJECT}"_AD.nii.gz
+  fslmaths "${DERIVATIVES}"/"${SUBJECT}"/"${SUBJECT}"_L2.nii.gz -add "${DERIVATIVES}"/"${SUBJECT}"/"${SUBJECT}"_L3.nii.gz -div 2 "${INDIVIDUAL}"/"${SUBJECT}"/RD/origdata/"${SUBJECT}"_RD.nii.gz
+}
+
+mask_diffusivity_measures() {
+  local _subject_dir="${INDIVIDUAL}"/"${SUBJECT}"
+  for _measure in "MD" "AD" "RD"; do
+    local _filename="${SUBJECT}"_"${_measure}".nii.gz
+    fslmaths "${_subject_dir}"/"${_measure}"/origdata/"${_filename}" -mas \
+      "${ANALYSIS}"/FA/"${SUBJECT}"_FA_mask.nii.gz \
+      "${_subject_dir}"/"${_measure}"/intermediary/"${SUBJECT}"
+  done
+}
+
+warp_masked_measures() {
+  local _subject_dir="${INDIVIDUAL}"/"${SUBJECT}"
+  for _measure in "MD" "AD" "RD"; do
+    local _intermediary_dir="${_subject_dir}"/"${_measure}"/intermediary
+    applywarp \
+      -i "${_intermediary_dir}"/"${SUBJECT}".nii.gz \
+      -o "${_intermediary_dir}"/"${SUBJECT}"_to_target.nii.gz \
+      -r "${FSLDIR}"/data/standard/FMRIB58_FA_1mm \
+      -w "${_subject_dir}"/FA/"${SUBJECT}"_FA_to_target_warp.nii.gz
+  done
+}
+
+mask_measure_targets() {
+  local _subject_dir="${INDIVIDUAL}"/"${SUBJECT}"
+  for _measure in "MD" "AD" "RD"; do
+    local _intermediary_dir="${_subject_dir}"/"${_measure}"/intermediary
+    fslmaths "${_intermediary_dir}"/"${SUBJECT}"_to_target.nii.gz \
+      -mas "${ENIGMA_ROOT}/ENIGMA_DTI_FA_mask.nii.gz" \
+      "${_intermediary_dir}"/"${SUBJECT}"_masked_"${_measure}".nii.gz
+  done
+}
+
+skeletonize_measures() {
+  local _subject_dir="${INDIVIDUAL}"/"${SUBJECT}"
+  for _measure in "MD" "AD" "RD"; do
+    tbss_skeleton \
+      -i "${ENIGMA_ROOT}"/ENIGMA_DTI_FA.nii.gz \
+      -p 0.049 \
+      "${ENIGMA_ROOT}"/ENIGMA_DTI_FA_skeleton_mask_dst.nii.gz \
+      "${FSLDIR}"/data/standard/LowerCingulum_1mm.nii.gz \
+      "${_subject_dir}"/FA/"${SUBJECT}"_masked_FA.nii.gz \
+      "${_subject_dir}"/"${_measure}"/stats/"${SUBJECT}"_masked_"${_measure}"_skel.nii.gz \
+        -a "${_subject_dir}"/"${_measure}"/intermediary/"${SUBJECT}"_masked_"${_measure}".nii.gz \
+        -s "${ENIGMA_ROOT}"/ENIGMA_DTI_FA_mask.nii.gz
+  done
+}
+
+# Make GNU parallel aware of these variables & functions
+export ANALYSIS
+export DERIVATIVES
+export ENIGMA_ROOT
+export -f derive_diffusivity_measures
+export -f mask_diffusivity_measures
+export -f warp_masked_measures
+export -f mask_measure_targets
+export -f skeletonize_measures
+
+derive_diffusivity_measures
+mask_diffusivity_measures
+warp_masked_measures
+mask_measure_targets
+skeletonize_measures


### PR DESCRIPTION
This PR incorporates diffusivity measure derivation into the script.

Diffusivity measure derivation is integrated in `utils/diffusivity.sh`, which is in turn called by `run_pipeline.sh`, which has been appropriately changed to call `utils/diffusitivity.sh` to facilitate parallel processing.

The script passed manual regression testing on Ubuntu Linux 20.04.6 LTS using `bash` version 5.0.17. As such, it is being merged into `master`.