### PR TITLE
feat!: automate tool/file downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,10 @@ This script was initially created by Pavan Anand, M.D. as a member of the Univer
 
 ## CHANGELOG
 
-### version 0.8.1
+### version 0.9.0
 
-This version represents a functional, stable, presentable, product for production use and is ready for others to test the whole DTI processing pipeline end-to-end. Huzzah! 🎉
+Turns out v0.8.1 actually contained within it _several_ bugs that were not caught in the testing environment. These have now been ironed out.
+
+Which means that _this_ version now represents a functional, stable, presentable, product for production use and is ready for others to test the whole DTI processing pipeline end-to-end. Huzzah (again)! 🎉
 
 Any remaining changes between stock ENIGMA files that were changed in any way to complete this project will be outlined in either a wiki in this GitHub repository or in this README file.

--- a/utils/analyze_roi.sh
+++ b/utils/analyze_roi.sh
@@ -13,14 +13,14 @@ readonly SKELETON="${1}"
 readonly MEASURE_PATH="$(dirname "$(dirname "${SKELETON}")")"
 readonly SESSION="$(basename "$(dirname "${MEASURE_PATH}")")"
 
-${ENIGMA_ROOT}/single_subject_roi "${ENIGMA_ROOT}/JHU_roi_look_up_table.txt" \
-  "${ENIGMA_ROOT}/ENIGMA_DTI_FA_SKELETON.nii.gz" \
-  "${ENIGMA_ROOT}/JHU_atlas.nii.gz" \
+${ENIGMA_TOOLS}/single_subject_roi "${REFERENCE_ROOT}/JHU/JHU_roi_look_up_table.txt" \
+  "${REFERENCE_ROOT}/ENIGMA/ENIGMA_DTI_FA_skeleton.nii.gz" \
+  "${REFERENCE_ROOT}/JHU/JHU_atlas.nii.gz" \
   "${MEASURE_PATH}/stats/${SESSION}_roi" \
   "${SKELETON}"
 
-${ENIGMA_ROOT}/average_subject_tracts \
+${ENIGMA_TOOLS}/average_subject_tracts \
   "${MEASURE_PATH}/stats/${SESSION}_roi.csv" \
-  "${MEASURE_PATH}/stats/${SESSION}_roi_av"g.csv
+  "${MEASURE_PATH}/stats/${SESSION}_roi_avg.csv"
 
 exit 0

--- a/utils/diffusivity.sh
+++ b/utils/diffusivity.sh
@@ -33,7 +33,8 @@ function mask_diffusivity_measures() {
 function warp_masked_measures() {
   local -r _subject_dir="${INDIVIDUAL}/${SUBJECT}"
   for _measure in "MD" "AD" "RD"; do
-    local -r _intermediary_dir="${_subject_dir}/${_measure}/intermediary"
+    # TODO: why can this not be read-only?
+    local _intermediary_dir="${_subject_dir}/${_measure}/intermediary"
     applywarp \
       -i "${_intermediary_dir}/${SUBJECT}.nii.gz" \
       -o "${_intermediary_dir}/${SUBJECT}_to_target.nii.gz" \
@@ -46,9 +47,10 @@ function warp_masked_measures() {
 function mask_measure_targets() {
   local -r _subject_dir="${INDIVIDUAL}/${SUBJECT}"
   for _measure in "MD" "AD" "RD"; do
-    local -r _intermediary_dir="${_subject_dir}/${_measure}/intermediary"
+    # TODO: why can this not be read-only?
+    local _intermediary_dir="${_subject_dir}/${_measure}/intermediary"
     fslmaths "${_intermediary_dir}/${SUBJECT}_to_target.nii.gz" \
-      -mas "${ENIGMA_ROOT}/ENIGMA_DTI_FA_mask.nii.gz" \
+      -mas "${REFERENCE_ROOT}/ENIGMA/ENIGMA_DTI_FA_mask.nii.gz" \
       "${_intermediary_dir}/${SUBJECT}_masked_${_measure}.nii.gz"
   done
   return 0
@@ -58,14 +60,14 @@ function skeletonize_measures() {
   local -r _subject_dir="${INDIVIDUAL}/${SUBJECT}"
   for _measure in "MD" "AD" "RD"; do
     tbss_skeleton \
-      -i "${ENIGMA_ROOT}/ENIGMA_DTI_FA.nii.gz" \
+      -i "${REFERENCE_ROOT}/ENIGMA/ENIGMA_DTI_FA.nii.gz" \
       -p 0.049 \
-      "${ENIGMA_ROOT}/ENIGMA_DTI_FA_skeleton_mask_dst.nii.gz" \
+      "${REFERENCE_ROOT}/ENIGMA/ENIGMA_DTI_FA_skeleton_mask_dst.nii.gz" \
       "${FSLDIR}/data/standard/LowerCingulum_1mm.nii.gz" \
       "${_subject_dir}/FA/intermediary/${SUBJECT}_masked_FA.nii.gz" \
       "${_subject_dir}/${_measure}/stats/${SUBJECT}_masked_${_measure}_skel.nii.gz" \
         -a "${_subject_dir}/${_measure}/intermediary/${SUBJECT}_masked_${_measure}.nii.gz" \
-        -s "${ENIGMA_ROOT}/ENIGMA_DTI_FA_mask.nii.gz"
+        -s "${REFERENCE_ROOT}/ENIGMA/ENIGMA_DTI_FA_mask.nii.gz"
   done
   return 0
 }
@@ -73,7 +75,8 @@ function skeletonize_measures() {
 # Make GNU parallel aware of these variables & functions
 export ANALYSIS
 export DERIVATIVES
-export ENIGMA_ROOT
+export ENIGMA_TOOLS
+export REFERENCE_ROOT
 export -f derive_diffusivity_measures
 export -f mask_diffusivity_measures
 export -f warp_masked_measures

--- a/utils/preprocess.sh
+++ b/utils/preprocess.sh
@@ -100,8 +100,8 @@ function eddy_correction(){  # TODO: minimize creation of extraneous functions
   # WARN: does *not* like spaces anywhere in file path arguments!
   # TODO: redefine tmp_dir as global, rename to all-caps to signify
   # WARN: Using local, readonly variable ($tmp_dir) in separate function...
-  local -r _eddy_output="${tmp_dir}/${2}_eddy_corrected"
-  eddy_correct "${1}" "${_eddy_output}" 0
+  readonly eddy_output="${tmp_dir}/${2}_eddy_corrected"  # TODO: make $eddy_output local
+  eddy_correct "${1}" "${eddy_output}" 0
 }
 
 function brain_extraction()  {  # TODO: minimize creation of extraneous functions
@@ -121,8 +121,8 @@ function brain_extraction()  {  # TODO: minimize creation of extraneous function
   # TODO: investigate feasibility of using `bet2` instead
   # TODO: redefine tmp_dir as global, rename to all-caps to signify
   # WARN: Using local, readonly variable ($tmp_dir) in separate function...
-  local -r _bet_output="${tmp_dir}/${2}_${file_basename}"
-  bet "${1}" "${_bet_output}" -F -f .3
+  readonly bet_output="${tmp_dir}/${2}_${file_basename}"  # TODO: make $bet_output local
+  bet "${1}" "${bet_output}" -F -f .3
   return 0
 }
 

--- a/utils/skeletonize.sh
+++ b/utils/skeletonize.sh
@@ -15,19 +15,19 @@ readonly analysis_root="${2}"
 
 id="$(basename "${session}")"
 
-cp "${analysis_root}/FA/${id}_*.nii.gz ${session}/FA"
+cp "${analysis_root}/FA/${id}_"*".nii.gz" "${session}/FA"
 
 fslmaths "${session}/FA/${id}_FA_to_target.nii.gz" \
-  -mas "${ENIGMA_ROOT}/ENIGMA_DTI_FA_skeleton_mask.nii.gz" \
+  -mas "${REFERENCE_ROOT}/ENIGMA/ENIGMA_DTI_FA_skeleton_mask.nii.gz" \
   "${session}/FA/${id}_masked_FA.nii.gz"
 
 tbss_skeleton \
   -i "${session}/FA/${id}_masked_FA.nii.gz" \
   -p 0.049 \
-  "${ENIGMA_ROOT}/ENIGMA_DTI_FA_skeleton_mask_dst.nii.gz" \
+  "${REFERENCE_ROOT}/ENIGMA/ENIGMA_DTI_FA_skeleton_mask_dst.nii.gz" \
   "${FSLDIR}/data/standard/LowerCingulum_1mm.nii.gz" \
   "${session}/FA/${id}_masked_FA.nii.gz" \
   "${session}/stats/${id}_masked_FA_skel.nii.gz" \
-  -s "${ENIGMA_ROOT}/ENIGMA_DTI_FA_mask.nii.gz"
+  -s "${REFERENCE_ROOT}/ENIGMA/ENIGMA_DTI_FA_mask.nii.gz"
 
 exit 0

--- a/utils/tbss.sh
+++ b/utils/tbss.sh
@@ -13,7 +13,7 @@ readonly INPUT="${1}"
 
 cd "${INPUT}"
 tbss_1_preproc *".nii.gz"  # Produces FA mask
-tbss_2_reg -t "${ENIGMA_ROOT}/ENIGMA_DTI_FA.nii.gz"  # Register to ENIGMA target
+tbss_2_reg -t "${REFERENCE_ROOT}/ENIGMA/ENIGMA_DTI_FA.nii.gz"  # Register to ENIGMA target
 tbss_3_postreg -S  # Create mean/all FA, mean FA mask, & mean FA skeleton
 
 exit 0


### PR DESCRIPTION
Binary files & other scripts/tools provided by the ENIGMA team are now located in `"${bids_root}/utils"` whereas reference files provided by ENIGMA & JHU are, respectively, located in `"${bids_root}/reference/"{ENIGMA,JHU}`. If such directories do not exist, the ENIGMA file repositories are automatically downloaded and organized into the proper directories.

This release also fixes several bugs that were accidentally introduced in the prior merge into the main branch.